### PR TITLE
Fix theme naming: persistent TextEditingController

### DIFF
--- a/lib/screens/theme_editor_screen.dart
+++ b/lib/screens/theme_editor_screen.dart
@@ -27,6 +27,7 @@ class _ThemeEditorScreenState extends State<ThemeEditorScreen> {
   late double _vignetteIntensity;
   late double _textShadowBlur;
   Color? _textShadowColor;
+  late TextEditingController _nameController;
 
   @override
   void initState() {
@@ -44,6 +45,13 @@ class _ThemeEditorScreenState extends State<ThemeEditorScreen> {
     _vignetteIntensity = base.vignetteIntensity;
     _textShadowBlur = base.textShadowBlur;
     _textShadowColor = base.textShadowColor;
+    _nameController = TextEditingController(text: _name);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
   }
 
   ReadingTheme get _currentTheme => ReadingTheme(
@@ -167,7 +175,7 @@ class _ThemeEditorScreenState extends State<ThemeEditorScreen> {
                 _SectionLabel('Name'),
                 const SizedBox(height: 8),
                 TextField(
-                  controller: TextEditingController(text: _name),
+                  controller: _nameController,
                   onChanged: (v) => setState(() => _name = v),
                   style: const TextStyle(color: Colors.white),
                   decoration: InputDecoration(


### PR DESCRIPTION
## Summary
- Fix backwards typing and single-character backspace when naming themes
- Root cause: `TextEditingController(text: _name)` was created in the build method, so every keystroke → setState → rebuild → new controller → cursor reset
- Fix: create the controller once in `initState`, use it in the `TextField`, dispose in `dispose`

Fixes #4

## Test plan
- [ ] Open theme editor, type a name — characters should appear in order
- [ ] Use backspace — should delete one character at a time normally
- [ ] Edit an existing theme name — cursor should be at the end, editing should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)