### PR TITLE
Hide system navbar during reading

### DIFF
--- a/lib/screens/reader_screen.dart
+++ b/lib/screens/reader_screen.dart
@@ -52,10 +52,17 @@ class _ReaderScreenState extends State<ReaderScreen> {
     _loadHighlights();
     // Save on scroll-stop: whenever scrolling settles, debounce and save.
     _chapterScrollController.addListener(_onScrollChanged);
+    // Hide system nav bar for immersive reading
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
   }
 
   @override
   void dispose() {
+    // Restore system nav bar when leaving reader
+    SystemChrome.setEnabledSystemUIMode(
+      SystemUiMode.manual,
+      overlays: SystemUiOverlay.values,
+    );
     _saveDebounce?.cancel();
     _chapterScrollController.removeListener(_onScrollChanged);
     _pageController.dispose();


### PR DESCRIPTION
## Summary
- Hide system navigation bar when entering the reader (immersiveSticky mode)
- Navbar reappears with a swipe from the bottom edge
- Full system UI restored when leaving the reader

Fixes #6

## Test plan
- [ ] Open a book — system navbar should disappear
- [ ] Swipe up from bottom edge — navbar briefly appears then hides again
- [ ] Press back to library — navbar returns and stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)